### PR TITLE
Small tweaks to build and deployment.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "eu.ehri-project"
 
 version := "1.0-SNAPSHOT"
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file(".")).enablePlugins(PlayScala, LauncherJarPlugin)
 
 scalaVersion := "2.13.9"
 
@@ -19,3 +19,7 @@ dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11
 
 // Adds additional packages into conf/routes
 // play.sbt.routes.RoutesKeys.routesImport += "eu.ehri-project.binders._"
+
+// Dist options
+topLevelDirectory := None
+

--- a/fabfile.py
+++ b/fabfile.py
@@ -29,7 +29,6 @@ def deploy(ctx, clean=False):
     ctx.put(file, remote="/tmp")
     ctx.run(f"mkdir -p {version_dir}")
     ctx.run(f"unzip /tmp/{base} -d {version_dir}")
-    ctx.run(f"mv {version_dir}/{name_no_extension}/* {version_dir}/.")
     symlink_target(ctx, version_dir, target_link)
     restart(ctx)
 


### PR DESCRIPTION
* Adds setting to remove top level dir from generated dist zip file, which slightly simplifies deployment.
* Enable the JarLauncherPlugin, which puts all the libs in a single jar and puts that on the classpath. This makes for a much easier to read command line